### PR TITLE
feat: Google tagを埋め込む

### DIFF
--- a/app/src/layout.gleam
+++ b/app/src/layout.gleam
@@ -3,7 +3,7 @@ import gleam/string
 import lustre/attribute.{attribute, class, href, rel, src, target}
 import lustre/element.{type Element}
 import lustre/element/html.{
-  a, aside, body, div, head, html, img, link, meta, nav, p, text,
+  a, aside, body, div, head, html, img, link, meta, nav, p, script, text,
 }
 
 // Site metadata constants
@@ -61,6 +61,21 @@ pub fn spa_frame(content: Element(Nil)) -> Element(Nil) {
         attribute("name", "keywords"),
         attribute("content", "関数型プログラミング,FP,関数型まつり,カンファレンス,技術イベント"),
       ]),
+      // Google Analytics
+      script(
+        [
+          attribute("async", ""),
+          src("https://www.googletagmanager.com/gtag/js?id=G-RG29W8HDWS"),
+        ],
+        "",
+      ),
+      script(
+        [],
+        "window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-RG29W8HDWS');",
+      ),
     ]),
     body([class("min-h-screen flex flex-col")], [
       navbar(),


### PR DESCRIPTION
Google Analyticsを利用する目的で、head内にGoogle tagを埋め込みます。

<img width="940" height="489" alt="スクリーンショット 2026-02-15 20 15 39" src="https://github.com/user-attachments/assets/5b68d707-f733-4960-989d-16df71cf5f67" />
