### PR TITLE
ci: GitHub Actions の各アクションを最新メジャーバージョンに更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Gleam
         uses: erlef/setup-beam@v1
         with:
@@ -24,7 +24,7 @@ jobs:
           gleam-version: "1.13.0"
           rebar3-version: "3"
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -35,11 +35,11 @@ jobs:
       - name: Build site
         run: npm run build
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "app/arctic_build"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,12 +9,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build Playwright Docker image
         run: npm run docker:build
       - name: Run Playwright tests in Docker
         run: npm run docker:run 'npm run pretest && npm run build:html && npx playwright test'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"


### PR DESCRIPTION
## Summary

GitHub Actions のワークフローで使用しているアクションを最新メジャーバージョンに更新。

| Action | 旧 | 新 |
|--------|-----|-----|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| actions/upload-artifact | v4 | v7 |

## 影響確認

- \`actions/checkout@v6\`: 認証情報の保管先が変わる程度。GitHub-hosted runner なら問題なし
- \`actions/setup-node@v6\`: \`cache: \"npm\"\` 指定の挙動は維持される
- \`actions/upload-pages-artifact@v4\` 以降は dotfiles を除外するが、リポジトリでトラックされている dotfile は \`.gitignore\` のみで \`app/public/\` 配下にはないため、CI 上のビルド成果物 \`app/arctic_build/\` に dotfile は含まれず影響なし
- その他は主に Node.js 24 化が中心でワークフロー構文の変更不要

## Test plan

- [x] \`test\` ワークフローが green
- [x] \`Playwright Tests\` ワークフローが green
- [ ] マージ後、\`Deploy to GitHub Pages\` が成功して GitHub Pages が更新される

Generated with Claude Code